### PR TITLE
fix running mvn install multiple times without clean

### DIFF
--- a/src/main/web/support/build/build-production.sh
+++ b/src/main/web/support/build/build-production.sh
@@ -20,7 +20,7 @@ echo "Running React build"
 react-scripts build
 
 echo "Moving build folder to $OUT"
-if [ -f "$OUT" ]
+if [ -d "$OUT" ]
 then
 	echo "Removing old $OUT"
 	rm -rf $OUT


### PR DESCRIPTION
when running mvn install multiple times, the command fails with the following log output:

```
[INFO] Moving build folder to ../../../target/classes/frontend
[INFO] mv: cannot move 'build' to '../../../target/classes/frontend/build': Directory not empty
[INFO] error Command failed with exit code 1.
[INFO] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51.477 s
[INFO] Finished at: 2023-09-18T17:19:59+02:00
[INFO] ------------------------------------------------------------------------
```

the build-production.sh should already remove the frontend folder, however the if condition uses -f, which checks if a file exists, instead of -d which checks for a directory