### PR TITLE
Composing Emails in the Webinterface doesn't work if SMTP Port is not 3025

### DIFF
--- a/src/main/java/uk/co/bigsoft/greenmail/http/commands/SmtpSendEmailCommand.java
+++ b/src/main/java/uk/co/bigsoft/greenmail/http/commands/SmtpSendEmailCommand.java
@@ -7,9 +7,6 @@ import io.javalin.http.Context;
 import uk.co.bigsoft.greenmail.http.dto.EmailDto;
 
 public class SmtpSendEmailCommand extends BaseHandler{
-
-    private static final String HOST = "localhost";
-    private static final int PORT = 3025;
     
     public SmtpSendEmailCommand(GreenMail greenMail){
         super(greenMail);
@@ -18,7 +15,7 @@ public class SmtpSendEmailCommand extends BaseHandler{
     @Override
     public void handle(Context ctx) throws Exception {
         EmailDto emailDto = ctx.bodyAsClass(EmailDto.class);
-        ServerSetup setup = new ServerSetup(PORT, HOST, ServerSetup.PROTOCOL_SMTP);
+        ServerSetup setup = new ServerSetup(gm.getSmtp().getPort(), gm.getSmtp().getBindTo(), ServerSetup.PROTOCOL_SMTP);
         setup.setServerStartupTimeout(ServerSetup.SERVER_STARTUP_TIMEOUT);
         GreenMailUtil.sendTextEmail(emailDto.getTo(),emailDto.getFrom(),emailDto.getSubject(),emailDto.getMsg(),setup);
         ctx.json("OK");


### PR DESCRIPTION
the port 3025 is hardcoded, however the currently used port of greenmail can be easily accessed 