### PR TITLE
Make Webport configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Using this flag will tell GreenMail HTTP to add Access-Control-Allow-Origin to t
 -Duk.co.bigsoft.greenmail.ac_anywhere
 ```
 
+### Run the webinterface on a different port
+By default, greenmail-http is accessible on port 7000. This can be changed by passing a different port to the following option:
+```
+-Duk.co.bigsoft.greenmail.web_port=8000
+```
+
 ## Developers
 I'm always happy to receive push requests. Just a couple of guidelines for a speedy merge.
 

--- a/src/main/java/uk/co/bigsoft/greenmail/Cfg.java
+++ b/src/main/java/uk/co/bigsoft/greenmail/Cfg.java
@@ -9,4 +9,8 @@ public class Cfg {
 	public boolean useAccessControlAnywhere() {
 		return System.getProperty("uk.co.bigsoft.greenmail.ac_anywhere") != null;
 	}
+
+	public int getWebPort() {
+		return Integer.parseInt(System.getProperty("uk.co.bigsoft.greenmail.web_port", "7000"));
+	}
 }

--- a/src/main/java/uk/co/bigsoft/greenmail/Main.java
+++ b/src/main/java/uk/co/bigsoft/greenmail/Main.java
@@ -52,7 +52,7 @@ public class Main {
 	}
 
 	private static void startHttpServer(GreenMail greenMail) {
-		Javalin app = Javalin.create().start(7000);
+		Javalin app = Javalin.create().start(cfg.getWebPort());
 		app.config.addStaticFiles("/frontend", Location.CLASSPATH);
 		app.get("/imap/:email/inbox", new ImapGetInBoxCommand(greenMail));
 		app.get("/imap/:email", new ImapListMailBoxCommand(greenMail));

--- a/src/main/web/package.json
+++ b/src/main/web/package.json
@@ -25,6 +25,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:7000",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/main/web/src/c/GmhUrl.js
+++ b/src/main/web/src/c/GmhUrl.js
@@ -1,5 +1,5 @@
 
-let base = 'http://localhost:7000'
+let base = window.location.origin;
 let mappings = {
 	//SERVER_CONFIG: '/',
 	ALL_IMAP: '/imap',


### PR DESCRIPTION
This change allows to change the port under which greenmail-http can be reached by setting the property `uk.co.bigsoft.greenmail.web_port`

For this to work, the frontend now uses the current browser url.
This means that if the firewall permits, the frontend can now also be used from a different computer, since the backend url is no longer hardcoded to localhost:7000.

This would break frontend development with `yarn start`, however setting "proxy" in package.json configures yarn to redirect all unknown request to this url.
Therefore yarn start still works and there should also no longer be any CORS problems.