### PR TITLE
fix not found on reload

### DIFF
--- a/src/main/java/uk/co/bigsoft/greenmail/Main.java
+++ b/src/main/java/uk/co/bigsoft/greenmail/Main.java
@@ -12,6 +12,7 @@ import uk.co.bigsoft.greenmail.http.commands.DeleteMailboxCommand;
 import uk.co.bigsoft.greenmail.http.commands.DeleteMessageCommand;
 import uk.co.bigsoft.greenmail.http.commands.AddUserCommand;
 import uk.co.bigsoft.greenmail.http.commands.DeleteUserCommand;
+import uk.co.bigsoft.greenmail.http.commands.FrontendCommand;
 import uk.co.bigsoft.greenmail.http.commands.ImapAllMessagesCommand;
 import uk.co.bigsoft.greenmail.http.commands.ImapGetInBoxCommand;
 import uk.co.bigsoft.greenmail.http.commands.ImapListMailBoxCommand;
@@ -54,6 +55,13 @@ public class Main {
 	private static void startHttpServer(GreenMail greenMail) {
 		Javalin app = Javalin.create().start(7000);
 		app.config.addStaticFiles("/frontend", Location.CLASSPATH);
+		app.get("/m/all", new FrontendCommand(greenMail));
+		app.get("/u/all", new FrontendCommand(greenMail));
+		app.get("/c/g", new FrontendCommand(greenMail));
+		app.get("/view/*", new FrontendCommand(greenMail));
+		app.get("/user/*", new FrontendCommand(greenMail));
+		app.get("/domain/*", new FrontendCommand(greenMail));
+		app.get("/folder/*", new FrontendCommand(greenMail));
 		app.get("/imap/:email/inbox", new ImapGetInBoxCommand(greenMail));
 		app.get("/imap/:email", new ImapListMailBoxCommand(greenMail));
 		app.get("/imap", new ImapAllMessagesCommand(greenMail));

--- a/src/main/java/uk/co/bigsoft/greenmail/http/commands/FrontendCommand.java
+++ b/src/main/java/uk/co/bigsoft/greenmail/http/commands/FrontendCommand.java
@@ -1,0 +1,22 @@
+package uk.co.bigsoft.greenmail.http.commands;
+
+import java.io.InputStream;
+
+import com.icegreen.greenmail.util.GreenMail;
+
+import io.javalin.http.Context;
+
+public class FrontendCommand extends BaseHandler {
+
+    public FrontendCommand(GreenMail greenMail) {
+        super(greenMail);
+    }
+
+    @Override
+    public void handle(Context ctx) throws Exception {
+        InputStream indexhtml = this.getClass().getClassLoader()
+                .getResourceAsStream("frontend/index.html");
+        ctx.result(indexhtml);
+        ctx.header("Content-Type", "text/html");
+    }
+}


### PR DESCRIPTION
the ui already contains reload-buttons to only reload the data, however if the user tries to reload the whole page, he get an empty page with the message "not found", since the backend is no configured to redirect the urls to index.html

this problem is not present when developing with `yarn start`, since all request are handled by yarn, which correctly redirects them

i did not find a a way to configure javalin to redirect unknown traffic to index.html, therefore i added a redirect for each path

Alternatives could be to change the urls to be easier to differentiate or to switch to a HashRouter in the frontend